### PR TITLE
Fix dashboard quick actions and modal links

### DIFF
--- a/admin/categories.php
+++ b/admin/categories.php
@@ -11,6 +11,8 @@ $category = new Category();
 
 // Obtener categorías
 $categories = $category->getAllCategories();
+$showAddModal = isset($_GET['action']) && $_GET['action'] === 'add';
+$editCategoryId = isset($_GET['edit']) ? intval($_GET['edit']) : 0;
 ?>
 
 <!DOCTYPE html>
@@ -314,6 +316,21 @@ $categories = $category->getAllCategories();
                 location.reload();
             }
         }
+
+        document.addEventListener('DOMContentLoaded', function() {
+            if ($showAddModal) {
+                const addModal = new bootstrap.Modal(document.getElementById('addCategoryModal'));
+                addModal.show();
+            }
+            if ($editCategoryId > 0) {
+                // Function editCategory might exist if implemented via AJAX
+                if (typeof editCategory === 'function') {
+                    editCategory($editCategoryId);
+                }
+                const editModal = new bootstrap.Modal(document.getElementById('editCategoryModal'));
+                editModal.show();
+            }
+        });
     </script>
 </body>
-</html> 
+</html>

--- a/admin/dashboard.php
+++ b/admin/dashboard.php
@@ -282,7 +282,7 @@ $recentProducts = $product->getAllProducts(5);
                                                     </span>
                                                 </td>
                                                 <td>
-                                                    <a href="product-edit.php?id=<?php echo $prod['id']; ?>" class="btn btn-sm btn-outline-primary">
+                                                <a href="products.php?edit=<?php echo $prod['id']; ?>" class="btn btn-sm btn-outline-primary">
                                                         <i class="fas fa-edit"></i>
                                                     </a>
                                                 </td>
@@ -303,10 +303,10 @@ $recentProducts = $product->getAllProducts(5);
                             </div>
                             <div class="card-body">
                                 <div class="d-grid gap-2">
-                                    <a href="product-add.php" class="btn btn-primary">
+                                    <a href="products.php?action=add" class="btn btn-primary">
                                         <i class="fas fa-plus me-2"></i>Agregar Producto
                                     </a>
-                                    <a href="category-add.php" class="btn btn-success">
+                                    <a href="categories.php?action=add" class="btn btn-success">
                                         <i class="fas fa-plus me-2"></i>Agregar Categoría
                                     </a>
                                     <a href="messages.php" class="btn btn-info">

--- a/admin/products.php
+++ b/admin/products.php
@@ -14,6 +14,8 @@ $category = new Category();
 // Obtener productos
 $products = $product->getAllProducts();
 $categories = $category->getAllCategories();
+$showAddModal = isset($_GET['action']) && $_GET['action'] === 'add';
+$editProductId = isset($_GET['edit']) ? intval($_GET['edit']) : 0;
 ?>
 
 <!DOCTYPE html>
@@ -573,6 +575,18 @@ $categories = $category->getAllCategories();
                 }
             });
         }
+
+        document.addEventListener('DOMContentLoaded', function() {
+            if ($showAddModal) {
+                const addModal = new bootstrap.Modal(document.getElementById('addProductModal'));
+                addModal.show();
+            }
+            if ($editProductId > 0) {
+                editProduct($editProductId);
+                const editModal = new bootstrap.Modal(document.getElementById('editProductModal'));
+                editModal.show();
+            }
+        });
     </script>
 </body>
-</html> 
+</html>


### PR DESCRIPTION
## Summary
- open product and category modals from dashboard quick actions
- allow adding `?action=add` and `?edit=` params in products and categories pages
- automatically show add/edit modals based on parameters

## Testing
- `php -l admin/dashboard.php`
- `php -l admin/products.php`
- `php -l admin/categories.php`
- `php test_dashboard.php > /tmp/test_dashboard.html`
- `php test_system.php 2>&1 | tail -n 5`

------
https://chatgpt.com/codex/tasks/task_b_6875b828d3648326b7f4fb8e74b4eacc