### PR TITLE
Fix product/category saving and add team admin

### DIFF
--- a/about.php
+++ b/about.php
@@ -1,5 +1,15 @@
 <?php
 require_once 'config/config.php';
+
+$teamFile = __DIR__ . '/data/team.json';
+$teamMembers = [];
+if (file_exists($teamFile)) {
+    $json = file_get_contents($teamFile);
+    $data = json_decode($json, true);
+    if (is_array($data)) {
+        $teamMembers = $data;
+    }
+}
 ?>
 <!DOCTYPE html>
 <html lang="es">
@@ -253,48 +263,20 @@ require_once 'config/config.php';
                 </div>
             </div>
             <div class="row">
-                <div class="col-lg-4 col-md-6 mb-4" data-aos="fade-up" data-aos-delay="100">
-                    <div class="card text-center border-0 shadow-lg">
-                        <div class="card-body p-4">
-                            <img src="https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?ixlib=rb-4.0.3&auto=format&fit=crop&w=400&q=80" 
-                                 alt="CEO" class="rounded-circle mb-3" style="width: 120px; height: 120px; object-fit: cover;">
-                            <h5 class="card-title">Carlos Mendoza</h5>
-                            <p class="text-muted">CEO & Fundador</p>
-                            <p class="card-text">
-                                Visionario tecnológico con más de 10 años de experiencia 
-                                en desarrollo de software y emprendimiento.
-                            </p>
+                <?php foreach ($teamMembers as $idx => $member): ?>
+                    <div class="col-lg-4 col-md-6 mb-4" data-aos="fade-up" data-aos-delay="<?php echo ($idx + 1) * 100; ?>">
+                        <div class="card text-center border-0 shadow-lg">
+                            <div class="card-body p-4">
+                                <img src="<?php echo htmlspecialchars($member['image']); ?>"
+                                     alt="<?php echo htmlspecialchars($member['role']); ?>" class="rounded-circle mb-3"
+                                     style="width: 120px; height: 120px; object-fit: cover;">
+                                <h5 class="card-title"><?php echo htmlspecialchars($member['name']); ?></h5>
+                                <p class="text-muted"><?php echo htmlspecialchars($member['role']); ?></p>
+                                <p class="card-text"><?php echo htmlspecialchars($member['description']); ?></p>
+                            </div>
                         </div>
                     </div>
-                </div>
-                <div class="col-lg-4 col-md-6 mb-4" data-aos="fade-up" data-aos-delay="200">
-                    <div class="card text-center border-0 shadow-lg">
-                        <div class="card-body p-4">
-                            <img src="https://images.unsplash.com/photo-1494790108755-2616b612b786?ixlib=rb-4.0.3&auto=format&fit=crop&w=400&q=80" 
-                                 alt="CTO" class="rounded-circle mb-3" style="width: 120px; height: 120px; object-fit: cover;">
-                            <h5 class="card-title">Ana Rodríguez</h5>
-                            <p class="text-muted">CTO & Desarrolladora</p>
-                            <p class="card-text">
-                                Experta en tecnologías emergentes y desarrollo de 
-                                aplicaciones web y móviles innovadoras.
-                            </p>
-                        </div>
-                    </div>
-                </div>
-                <div class="col-lg-4 col-md-6 mb-4" data-aos="fade-up" data-aos-delay="300">
-                    <div class="card text-center border-0 shadow-lg">
-                        <div class="card-body p-4">
-                            <img src="https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?ixlib=rb-4.0.3&auto=format&fit=crop&w=400&q=80" 
-                                 alt="CMO" class="rounded-circle mb-3" style="width: 120px; height: 120px; object-fit: cover;">
-                            <h5 class="card-title">Luis Torres</h5>
-                            <p class="text-muted">CMO & Especialista en Productos</p>
-                            <p class="card-text">
-                                Experto en marketing digital y productos naturales 
-                                con amplia experiencia en el mercado latinoamericano.
-                            </p>
-                        </div>
-                    </div>
-                </div>
+                <?php endforeach; ?>
             </div>
         </div>
     </section>

--- a/admin/dashboard.php
+++ b/admin/dashboard.php
@@ -84,6 +84,12 @@ $recentProducts = $product->getAllProducts(5);
                     </a>
                 </li>
                 <li>
+                    <a href="team.php">
+                        <i class="fas fa-users-cog"></i>
+                        Equipo
+                    </a>
+                </li>
+                <li>
                     <a href="settings.php">
                         <i class="fas fa-cog"></i>
                         Configuración

--- a/admin/messages.php
+++ b/admin/messages.php
@@ -100,6 +100,12 @@ $messages = [
                     </a>
                 </li>
                 <li>
+                    <a href="team.php">
+                        <i class="fas fa-users-cog"></i>
+                        Equipo
+                    </a>
+                </li>
+                <li>
                     <a href="settings.php">
                         <i class="fas fa-cog"></i>
                         Configuración

--- a/admin/orders.php
+++ b/admin/orders.php
@@ -74,6 +74,12 @@ $orders = $orderModel->getAllOrders();
                     </a>
                 </li>
                 <li>
+                    <a href="team.php">
+                        <i class="fas fa-users-cog"></i>
+                        Equipo
+                    </a>
+                </li>
+                <li>
                     <a href="settings.php">
                         <i class="fas fa-cog"></i>
                         Configuración

--- a/admin/process_product.php
+++ b/admin/process_product.php
@@ -67,12 +67,6 @@ try {
                 throw new Exception('Categoría no válida');
             }
 
-            // Obtener producto existente para conservar el SKU
-            $existing = $product->getProductById($productId);
-            if (!$existing) {
-                throw new Exception('Producto no encontrado');
-            }
-
             $productData = [
                 'name' => $name,
                 'description' => $description,

--- a/admin/products.php
+++ b/admin/products.php
@@ -77,6 +77,12 @@ $editProductId = isset($_GET['edit']) ? intval($_GET['edit']) : 0;
                     </a>
                 </li>
                 <li>
+                    <a href="team.php">
+                        <i class="fas fa-users-cog"></i>
+                        Equipo
+                    </a>
+                </li>
+                <li>
                     <a href="settings.php">
                         <i class="fas fa-cog"></i>
                         Configuración

--- a/admin/settings.php
+++ b/admin/settings.php
@@ -82,6 +82,12 @@ $settings = [
                         Mensajes
                     </a>
                 </li>
+                <li>
+                    <a href="team.php">
+                        <i class="fas fa-users-cog"></i>
+                        Equipo
+                    </a>
+                </li>
                 <li class="active">
                     <a href="settings.php">
                         <i class="fas fa-cog"></i>

--- a/admin/team.php
+++ b/admin/team.php
@@ -1,0 +1,133 @@
+<?php
+require_once __DIR__ . '/../config/config.php';
+
+if (!isLoggedIn() || !isAdmin()) {
+    redirect(SITE_URL . '/auth/login.php');
+}
+
+$teamFile = __DIR__ . '/../data/team.json';
+$team = [];
+if (file_exists($teamFile)) {
+    $data = json_decode(file_get_contents($teamFile), true);
+    if (is_array($data)) {
+        $team = $data;
+    }
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $newTeam = [];
+    $count = count($_POST['name']);
+    for ($i = 0; $i < $count; $i++) {
+        $name = cleanInput($_POST['name'][$i] ?? '');
+        $role = cleanInput($_POST['role'][$i] ?? '');
+        $desc = cleanInput($_POST['description'][$i] ?? '');
+        $image = $team[$i]['image'] ?? 'assets/images/placeholder.jpg';
+        if (isset($_FILES['image']['tmp_name'][$i]) && $_FILES['image']['tmp_name'][$i]) {
+            $uploadDir = __DIR__ . '/../assets/images/team/';
+            if (!file_exists($uploadDir)) {
+                mkdir($uploadDir, 0755, true);
+            }
+            $filename = uniqid() . '_' . basename($_FILES['image']['name'][$i]);
+            move_uploaded_file($_FILES['image']['tmp_name'][$i], $uploadDir . $filename);
+            $image = 'assets/images/team/' . $filename;
+        }
+        $newTeam[] = [
+            'name' => $name,
+            'role' => $role,
+            'description' => $desc,
+            'image' => $image
+        ];
+    }
+    file_put_contents($teamFile, json_encode($newTeam, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE));
+    $team = $newTeam;
+    $success = true;
+}
+?>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Equipo - Admin <?php echo SITE_NAME; ?></title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0/css/all.min.css" rel="stylesheet">
+    <link href="../assets/css/admin.css" rel="stylesheet">
+</head>
+<body>
+<div class="wrapper">
+    <nav id="sidebar" class="sidebar">
+        <div class="sidebar-header">
+            <h3><i class="fas fa-flask"></i> Admin Panel</h3>
+        </div>
+        <ul class="list-unstyled components">
+            <li><a href="dashboard.php"><i class="fas fa-tachometer-alt"></i>Dashboard</a></li>
+            <li><a href="products.php"><i class="fas fa-box"></i>Productos</a></li>
+            <li><a href="categories.php"><i class="fas fa-tags"></i>Categorías</a></li>
+            <li><a href="orders.php"><i class="fas fa-shopping-cart"></i>Pedidos</a></li>
+            <li><a href="users.php"><i class="fas fa-users"></i>Usuarios</a></li>
+            <li><a href="messages.php"><i class="fas fa-envelope"></i>Mensajes</a></li>
+            <li class="active"><a href="team.php"><i class="fas fa-users-cog"></i>Equipo</a></li>
+            <li><a href="settings.php"><i class="fas fa-cog"></i>Configuración</a></li>
+        </ul>
+        <div class="sidebar-footer">
+            <a href="../index.php" class="btn btn-outline-light btn-sm"><i class="fas fa-eye me-2"></i>Ver Sitio</a>
+            <a href="../auth/logout.php" class="btn btn-outline-danger btn-sm"><i class="fas fa-sign-out-alt me-2"></i>Salir</a>
+        </div>
+    </nav>
+    <div id="content">
+        <nav class="navbar navbar-expand-lg navbar-light bg-light">
+            <div class="container-fluid">
+                <button type="button" id="sidebarCollapse" class="btn btn-primary"><i class="fas fa-bars"></i></button>
+                <div class="ms-auto">
+                    <div class="dropdown">
+                        <button class="btn btn-outline-primary dropdown-toggle" type="button" id="userDropdown" data-bs-toggle="dropdown">
+                            <i class="fas fa-user me-2"></i><?php echo $_SESSION['user_name']; ?>
+                        </button>
+                        <ul class="dropdown-menu dropdown-menu-end">
+                            <li><a class="dropdown-item" href="profile.php">Mi Perfil</a></li>
+                            <li><hr class="dropdown-divider"></li>
+                            <li><a class="dropdown-item" href="../auth/logout.php">Cerrar Sesión</a></li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </nav>
+        <div class="container-fluid">
+            <h1 class="h3 mb-4">Nuestro Equipo</h1>
+            <?php if (!empty($success)): ?>
+                <div class="alert alert-success">Equipo actualizado correctamente</div>
+            <?php endif; ?>
+            <form method="post" enctype="multipart/form-data">
+                <?php foreach ($team as $i => $member): ?>
+                    <div class="card mb-3">
+                        <div class="card-body">
+                            <div class="row g-3 align-items-end">
+                                <div class="col-md-3 text-center">
+                                    <img src="<?php echo htmlspecialchars($member['image']); ?>" class="rounded-circle mb-2" style="width:100px;height:100px;object-fit:cover;">
+                                    <input type="file" name="image[]" class="form-control" accept="image/*">
+                                </div>
+                                <div class="col-md-3">
+                                    <label class="form-label">Nombre</label>
+                                    <input type="text" name="name[]" class="form-control" value="<?php echo htmlspecialchars($member['name']); ?>" required>
+                                </div>
+                                <div class="col-md-3">
+                                    <label class="form-label">Cargo</label>
+                                    <input type="text" name="role[]" class="form-control" value="<?php echo htmlspecialchars($member['role']); ?>" required>
+                                </div>
+                                <div class="col-md-3">
+                                    <label class="form-label">Descripción</label>
+                                    <textarea name="description[]" class="form-control" rows="3" required><?php echo htmlspecialchars($member['description']); ?></textarea>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                <?php endforeach; ?>
+                <button type="submit" class="btn btn-primary">Guardar Cambios</button>
+            </form>
+        </div>
+    </div>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"></script>
+<script src="../assets/js/admin.js"></script>
+</body>
+</html>

--- a/admin/users.php
+++ b/admin/users.php
@@ -72,6 +72,12 @@ $users = $user->getAllUsers();
                     </a>
                 </li>
                 <li>
+                    <a href="team.php">
+                        <i class="fas fa-users-cog"></i>
+                        Equipo
+                    </a>
+                </li>
+                <li>
                     <a href="settings.php">
                         <i class="fas fa-cog"></i>
                         Configuración

--- a/classes/Category.php
+++ b/classes/Category.php
@@ -111,6 +111,34 @@ class Category {
             return false;
         }
     }
+
+    // Obtener categoría por nombre
+    public function getCategoryByName($name) {
+        try {
+            $sql = "SELECT * FROM categories WHERE name = ? LIMIT 1";
+            $stmt = $this->db->prepare($sql);
+            $stmt->execute([$name]);
+            return $stmt->fetch();
+        } catch(PDOException $e) {
+            return false;
+        }
+    }
+
+    // Alternar estado activo/inactivo
+    public function toggleActive($id) {
+        try {
+            $cat = $this->getCategoryById($id);
+            if (!$cat) return false;
+            $newStatus = $cat['status'] === 'active' ? 'inactive' : 'active';
+            $stmt = $this->db->prepare("UPDATE categories SET status = ? WHERE id = ?");
+            if ($stmt->execute([$newStatus, $id])) {
+                return $newStatus === 'active';
+            }
+            return false;
+        } catch(PDOException $e) {
+            return false;
+        }
+    }
     
     // Obtener categorías con conteo de productos
     public function getCategoriesWithProductCount() {

--- a/data/team.json
+++ b/data/team.json
@@ -1,0 +1,20 @@
+[
+  {
+    "name": "Carlos Mendoza",
+    "role": "CEO & Fundador",
+    "description": "Visionario tecnológico con más de 10 años de experiencia en desarrollo de software y emprendimiento.",
+    "image": "assets/images/placeholder.jpg"
+  },
+  {
+    "name": "Ana Rodríguez",
+    "role": "CTO & Desarrolladora",
+    "description": "Experta en tecnologías emergentes y desarrollo de aplicaciones web y móviles innovadoras.",
+    "image": "assets/images/placeholder.jpg"
+  },
+  {
+    "name": "Luis Torres",
+    "role": "CMO & Especialista en Productos",
+    "description": "Experto en marketing digital y productos naturales con amplia experiencia en el mercado latinoamericano.",
+    "image": "assets/images/placeholder.jpg"
+  }
+]


### PR DESCRIPTION
## Summary
- fix `create` case in `process_product.php`
- rewrite category processing logic and add image upload
- enhance Category class with helper methods
- add team management page and new team data file
- allow editing team data from dashboard
- update about page to load team info dynamically
- add menu link for new Team page across admin

## Testing
- `php -l admin/process_product.php`
- `php -l admin/process_category.php`
- `php -l admin/team.php`
- `php -l about.php`
- `php -l admin/categories.php`
- `php test_system.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_6875d82d1fac83268254478ed8c46117