### PR TITLE
Fix upload placeholders and settings warnings

### DIFF
--- a/admin/settings.php
+++ b/admin/settings.php
@@ -18,6 +18,8 @@ $settings = [
     'facebook_url' => 'https://facebook.com/alquimiatechnologic',
     'instagram_url' => 'https://instagram.com/alquimiatechnologic',
     'whatsapp_url' => 'https://wa.me/593983015307',
+    'logo_url' => '',
+    'favicon_url' => '',
     'maintenance_mode' => false,
     'allow_registration' => true,
     'email_notifications' => true
@@ -200,7 +202,8 @@ $settings = [
                                                         <div class="upload-area" data-folder="settings">
                                                             <div class="upload-placeholder">
                                                                 <i class="fas fa-cloud-upload-alt fa-2x text-muted mb-2"></i>
-                                                                <p class="text-muted small">Selecciona una imagen</p>
+                                                                <p class="text-muted">Arrastra imágenes aquí o haz clic para seleccionar</p>
+                                                                <p class="text-muted small">Formatos: JPG, PNG, GIF, WEBP (máx. 5MB cada una)</p>
                                                             </div>
                                                             <input type="file" name="logo_file" accept="image/*" style="display:none;">
                                                         </div>
@@ -215,7 +218,8 @@ $settings = [
                                                         <div class="upload-area" data-folder="settings">
                                                             <div class="upload-placeholder">
                                                                 <i class="fas fa-cloud-upload-alt fa-2x text-muted mb-2"></i>
-                                                                <p class="text-muted small">Selecciona una imagen</p>
+                                                                <p class="text-muted">Arrastra imágenes aquí o haz clic para seleccionar</p>
+                                                                <p class="text-muted small">Formatos: JPG, PNG, GIF, WEBP (máx. 5MB cada una)</p>
                                                             </div>
                                                             <input type="file" name="favicon_file" accept="image/*" style="display:none;">
                                                         </div>
@@ -449,6 +453,7 @@ $settings = [
     <script src="../assets/js/admin.js"></script>
     
     <script>
+        const csrfToken = '<?php echo generateCSRFToken(); ?>';
         // Settings management functions
         function saveSettings() {
             // Collect all form data


### PR DESCRIPTION
## Summary
- add missing logo and favicon settings keys
- improve logo and favicon upload placeholders
- define CSRF token in settings script

## Testing
- `php -l admin/settings.php`
- `php -l admin/upload_handler.php`
- `php -l test_system.php`
- `php -l test_dashboard.php`
- `php -l test_correcciones.php`
- `php -l test_mejoras_sistema.php`
- `php -l test_sistema_completo.php`


------
https://chatgpt.com/codex/tasks/task_b_6875dfc95f108326abf32fa043cb71e8