### PR TITLE
Enable file selection for image uploads

### DIFF
--- a/admin/categories.php
+++ b/admin/categories.php
@@ -236,7 +236,7 @@ $editCategoryId = isset($_GET['edit']) ? intval($_GET['edit']) : 0;
                                     <i class="fas fa-cloud-upload-alt fa-2x text-muted mb-2"></i>
                                     <p class="text-muted small">Selecciona una imagen</p>
                                 </div>
-                                <input type="file" name="images[]" accept="image/*" style="display:none;">
+                                <input type="file" id="categoryImageUpload" name="images[]" accept="image/*" class="form-control mt-2">
                             </div>
                             <div id="categoryImagePreview" class="image-preview mt-2"></div>
                             <input type="hidden" name="image_json" id="categoryImagesJson">
@@ -281,7 +281,7 @@ $editCategoryId = isset($_GET['edit']) ? intval($_GET['edit']) : 0;
                                     <i class="fas fa-cloud-upload-alt fa-2x text-muted mb-2"></i>
                                     <p class="text-muted small">Selecciona una imagen</p>
                                 </div>
-                                <input type="file" name="images[]" accept="image/*" style="display:none;">
+                                <input type="file" id="editCategoryImageUpload" name="images[]" accept="image/*" class="form-control mt-2">
                             </div>
                             <div id="editCategoryImagePreview" class="image-preview mt-2"></div>
                             <input type="hidden" name="image_json" id="editCategoryImagesJson">

--- a/admin/products.php
+++ b/admin/products.php
@@ -282,7 +282,7 @@ $editProductId = isset($_GET['edit']) ? intval($_GET['edit']) : 0;
                                             <p class="text-muted">Arrastra imágenes aquí o haz clic para seleccionar</p>
                                             <p class="text-muted small">Formatos: JPG, PNG, GIF, WEBP (máx. 5MB cada una)</p>
                                         </div>
-                                        <input type="file" id="imageUpload" name="images[]" multiple accept="image/*" style="display: none;">
+                                        <input type="file" id="imageUpload" name="images[]" multiple accept="image/*" class="form-control mt-2">
                                     </div>
                                     <div id="imagePreview" class="mt-3"></div>
                                     <input type="hidden" name="images_json" id="imagesJson">
@@ -359,7 +359,7 @@ $editProductId = isset($_GET['edit']) ? intval($_GET['edit']) : 0;
                                             <p class="text-muted">Arrastra imágenes aquí o haz clic para seleccionar</p>
                                             <p class="text-muted small">Formatos: JPG, PNG, GIF, WEBP (máx. 5MB cada una)</p>
                                         </div>
-                                        <input type="file" id="editImageUpload" name="images[]" multiple accept="image/*" style="display: none;">
+                                        <input type="file" id="editImageUpload" name="images[]" multiple accept="image/*" class="form-control mt-2">
                                     </div>
                                     <div id="editImagePreview" class="mt-3"></div>
                                     <input type="hidden" name="images_json" id="editImagesJson">


### PR DESCRIPTION
## Summary
- show file input fields in product and category modals

## Testing
- `php -d detect_unicode=0 test_dashboard.php > /tmp/test_dashboard_output.html`
- `php -d detect_unicode=0 test_system.php > /tmp/test_system_output.html` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_6875e242e7708326aba99905cdf555db