### PR TITLE
Fix image upload preview for products

### DIFF
--- a/admin/products.php
+++ b/admin/products.php
@@ -285,7 +285,7 @@ $editProductId = isset($_GET['edit']) ? intval($_GET['edit']) : 0;
                                         </div>
                                         <input type="file" id="imageUpload" name="images[]" multiple accept="image/*" class="form-control mt-2">
                                     </div>
-                                    <div id="imagePreview" class="mt-3"></div>
+                                    <div id="productImagePreview" class="image-preview mt-3"></div>
                                     <input type="hidden" name="images_json" id="imagesJson">
                                 </div>
                                 <div class="mb-3">
@@ -362,7 +362,7 @@ $editProductId = isset($_GET['edit']) ? intval($_GET['edit']) : 0;
                                         </div>
                                         <input type="file" id="editImageUpload" name="images[]" multiple accept="image/*" class="form-control mt-2">
                                     </div>
-                                    <div id="editImagePreview" class="mt-3"></div>
+                                    <div id="editImagePreview" class="image-preview mt-3"></div>
                                     <input type="hidden" name="images_json" id="editImagesJson">
                                 </div>
                                 <div class="mb-3">
@@ -493,7 +493,7 @@ $editProductId = isset($_GET['edit']) ? intval($_GET['edit']) : 0;
                     const modal = bootstrap.Modal.getInstance(document.getElementById('addProductModal'));
                     modal.hide();
                     form.reset();
-                    document.getElementById('imagePreview').innerHTML = '';
+                    document.getElementById('productImagePreview').innerHTML = '';
                     document.getElementById('imagesJson').value = '';
                     location.reload();
                 } else {


### PR DESCRIPTION
## Summary
- update product image preview element ID
- add missing image-preview class for product previews

## Testing
- `php -l admin/products.php`
- `php -l admin/categories.php`
- `php test_dashboard.php`
- `php test_system.php` *(fails: Error de conexión: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_6875e68bd78c8326bb8d664a6918eb0f