### PR TITLE
Fix image upload preservation

### DIFF
--- a/admin/process_category.php
+++ b/admin/process_category.php
@@ -80,6 +80,12 @@ try {
             $images = json_decode($image_json, true);
             if (json_last_error() !== JSON_ERROR_NONE) { $images = []; }
             $image = isset($images[0]) ? $images[0] : null;
+            if ($image === null) {
+                $existing = $category->getCategoryById($categoryId);
+                if ($existing && $existing['image']) {
+                    $image = $existing['image'];
+                }
+            }
             
             if ($categoryId <= 0) {
                 throw new Exception('ID de categoría inválido');

--- a/admin/process_product.php
+++ b/admin/process_product.php
@@ -34,11 +34,17 @@ try {
             $featured = isset($_POST['featured']) ? (int)$_POST['featured'] : 0;
             $discount_percentage = (float)($_POST['discount_percentage'] ?? 0);
             $images_json = $_POST['images_json'] ?? '[]';
-            
+
             // Validar JSON de imágenes
             $images = json_decode($images_json, true);
             if (json_last_error() !== JSON_ERROR_NONE) {
                 $images = [];
+            }
+            if (empty($images)) {
+                $existingProd = $product->getProductById($productId);
+                if ($existingProd && !empty($existingProd['images'])) {
+                    $images = json_decode($existingProd['images'], true) ?: [];
+                }
             }
             
             // Validaciones

--- a/classes/Category.php
+++ b/classes/Category.php
@@ -50,13 +50,17 @@ class Category {
         try {
             $sql = "INSERT INTO categories (name, description, image, slug) VALUES (?, ?, ?, ?)";
             $stmt = $this->db->prepare($sql);
-            
-            return $stmt->execute([
+
+            if ($stmt->execute([
                 $data['name'],
                 $data['description'] ?? null,
                 $data['image'] ?? null,
                 $data['slug']
-            ]);
+            ])) {
+                return $this->db->lastInsertId();
+            }
+
+            return false;
         } catch(PDOException $e) {
             return false;
         }

--- a/product.php
+++ b/product.php
@@ -17,6 +17,17 @@ if (!$productData) {
     exit;
 }
 
+// Procesar imágenes del producto
+$productImages = [];
+if (!empty($productData['images'])) {
+    $productImages = json_decode($productData['images'], true);
+    if (json_last_error() !== JSON_ERROR_NONE) {
+        $productImages = [];
+    }
+}
+
+$mainImage = $productImages[0] ?? 'https://images.unsplash.com/photo-1560472354-b33ff0c44a43?ixlib=rb-4.0.3&auto=format&fit=crop&w=800&q=80';
+
 // Obtener categoría del producto
 $productCategory = $category->getCategoryById($productData['category_id']);
 
@@ -146,17 +157,23 @@ $relatedProducts = $product->getRelatedProducts($id, $productData['category_id']
                 <div class="col-lg-6 mb-4" data-aos="fade-right">
                     <div class="product-gallery">
                         <div class="main-image mb-3">
-                            <img src="<?php echo $productData['image'] ?: 'https://images.unsplash.com/photo-1560472354-b33ff0c44a43?ixlib=rb-4.0.3&auto=format&fit=crop&w=800&q=80'; ?>" 
-                                 alt="<?php echo htmlspecialchars($productData['name']); ?>" 
+                            <img src="<?php echo htmlspecialchars($mainImage); ?>"
+                                 alt="<?php echo htmlspecialchars($productData['name']); ?>"
                                  class="img-fluid rounded-custom shadow-lg" id="mainImage">
                         </div>
                         <div class="thumbnail-images d-flex gap-2">
-                            <img src="<?php echo $productData['image'] ?: 'https://images.unsplash.com/photo-1560472354-b33ff0c44a43?ixlib=rb-4.0.3&auto=format&fit=crop&w=200&q=80'; ?>" 
-                                 alt="Thumbnail 1" class="img-thumbnail thumbnail-img active" onclick="changeImage(this)">
-                            <img src="https://images.unsplash.com/photo-1558618666-fcd25c85cd64?ixlib=rb-4.0.3&auto=format&fit=crop&w=200&q=80" 
-                                 alt="Thumbnail 2" class="img-thumbnail thumbnail-img" onclick="changeImage(this)">
-                            <img src="https://images.unsplash.com/photo-1558618666-fcd25c85cd64?ixlib=rb-4.0.3&auto=format&fit=crop&w=200&q=80" 
-                                 alt="Thumbnail 3" class="img-thumbnail thumbnail-img" onclick="changeImage(this)">
+                            <?php if (!empty($productImages)): ?>
+                                <?php foreach ($productImages as $index => $imgUrl): ?>
+                                    <img src="<?php echo htmlspecialchars($imgUrl); ?>"
+                                         alt="Thumbnail"
+                                         class="img-thumbnail thumbnail-img <?php echo $index === 0 ? 'active' : ''; ?>"
+                                         onclick="changeImage(this)">
+                                <?php endforeach; ?>
+                            <?php else: ?>
+                                <img src="<?php echo htmlspecialchars($mainImage); ?>"
+                                     alt="Thumbnail" class="img-thumbnail thumbnail-img active"
+                                     onclick="changeImage(this)">
+                            <?php endif; ?>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- return category ID after creation
- keep existing category/product images when no new image is uploaded
- improve product page to read images array

## Testing
- `php test_system.php` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_6876e711e83c8326af9e90effdf2ba05