### PR TITLE
Fix image paths for product display

### DIFF
--- a/category.php
+++ b/category.php
@@ -20,6 +20,10 @@ if (!$currentCategory) {
 }
 
 $products = $product->getProductsByCategory($currentCategory['id'], $limit, $offset);
+foreach ($products as &$p) {
+    $p['image'] = Product::getImagePath($p);
+}
+unset($p);
 $totalProducts = $product->getProductCountByCategory($currentCategory['id']);
 $totalPages = ceil($totalProducts / $limit);
 ?>

--- a/classes/Order.php
+++ b/classes/Order.php
@@ -114,7 +114,11 @@ class Order {
     public function getOrderItems($orderId) {
         try {
             $stmt = $this->pdo->prepare("
-                SELECT oi.*, p.name as product_name, p.image as product_image
+                SELECT
+                    oi.*,
+                    p.name as product_name,
+                    p.images as product_images,
+                    p.slug as product_slug
                 FROM order_items oi
                 LEFT JOIN products p ON oi.product_id = p.id
                 WHERE oi.order_id = ?

--- a/classes/Product.php
+++ b/classes/Product.php
@@ -283,7 +283,7 @@ class Product {
     // Obtener cantidad de productos por categoría
     public function getProductCountByCategory($categoryId) {
         try {
-            $sql = "SELECT COUNT(*) as total FROM products 
+            $sql = "SELECT COUNT(*) as total FROM products
                     WHERE category_id = ? AND status = 'active'";
             
             $stmt = $this->db->prepare($sql);
@@ -294,6 +294,31 @@ class Product {
         } catch(PDOException $e) {
             return 0;
         }
+    }
+
+    /**
+     * Obtener la imagen principal de un producto.
+     * Devuelve la primera imagen del campo JSON o una imagen basada en el slug.
+     */
+    public static function getImagePath($product) {
+        $imagesJson = is_array($product) ? ($product['images'] ?? '') : $product;
+
+        if ($imagesJson) {
+            $images = json_decode($imagesJson, true);
+            if (json_last_error() === JSON_ERROR_NONE && !empty($images[0])) {
+                return $images[0];
+            }
+        }
+
+        $slug = is_array($product) ? ($product['slug'] ?? '') : '';
+        if ($slug) {
+            $path = 'assets/images/products/' . $slug . '.jpg';
+            if (file_exists(__DIR__ . '/../' . $path)) {
+                return $path;
+            }
+        }
+
+        return 'assets/images/placeholder.jpg';
     }
 }
 ?> 

--- a/index.php
+++ b/index.php
@@ -8,6 +8,10 @@ $category = new Category();
 
 // Obtener productos destacados
 $featuredProducts = $product->getFeaturedProducts(8);
+foreach ($featuredProducts as &$fp) {
+    $fp['image'] = Product::getImagePath($fp);
+}
+unset($fp);
 $categories = $category->getAllCategories();
 ?>
 

--- a/orders.php
+++ b/orders.php
@@ -2,6 +2,7 @@
 require_once 'config/config.php';
 require_once 'classes/User.php';
 require_once 'classes/Order.php';
+require_once 'classes/Product.php';
 
 // Verificar si el usuario está logueado
 if (!isLoggedIn()) {
@@ -24,6 +25,13 @@ if ($orderId) {
         exit;
     }
     $orderItems = $order->getOrderItems($orderId);
+    foreach ($orderItems as &$item) {
+        $item['image'] = Product::getImagePath([
+            'images' => $item['product_images'] ?? '',
+            'slug'   => $item['product_slug'] ?? ''
+        ]);
+    }
+    unset($item);
 } else {
     $userOrders = $order->getOrdersByUserId($_SESSION['user_id']);
 }

--- a/product.php
+++ b/product.php
@@ -33,6 +33,10 @@ $productCategory = $category->getCategoryById($productData['category_id']);
 
 // Obtener productos relacionados
 $relatedProducts = $product->getRelatedProducts($id, $productData['category_id'], 4);
+foreach ($relatedProducts as &$rp) {
+    $rp['image'] = Product::getImagePath($rp);
+}
+unset($rp);
 ?>
 
 <!DOCTYPE html>

--- a/products.php
+++ b/products.php
@@ -22,6 +22,11 @@ if ($search) {
     $products = $product->getAllProducts($limit, $offset);
 }
 
+foreach ($products as &$p) {
+    $p['image'] = Product::getImagePath($p);
+}
+unset($p);
+
 $categories = $category->getAllCategories();
 ?>
 


### PR DESCRIPTION
## Summary
- calculate product image paths from JSON or slug
- fix order item query to expose product image data
- populate image values in product listing pages and detail view

## Testing
- `php -l classes/Product.php`
- `php -l classes/Order.php`
- `php -l products.php`
- `php -l index.php`
- `php -l category.php`
- `php -l product.php`
- `php -l orders.php`
- `php test_system.php` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_6876ea727434832680ff46079140b6c3