### PR TITLE
Improve product image fallback

### DIFF
--- a/classes/Product.php
+++ b/classes/Product.php
@@ -312,9 +312,12 @@ class Product {
 
         $slug = is_array($product) ? ($product['slug'] ?? '') : '';
         if ($slug) {
-            $path = 'assets/images/products/' . $slug . '.jpg';
-            if (file_exists(__DIR__ . '/../' . $path)) {
-                return $path;
+            $extensions = ['jpg', 'jpeg', 'png', 'webp', 'gif'];
+            foreach ($extensions as $ext) {
+                $path = "assets/images/products/{$slug}.{$ext}";
+                if (file_exists(__DIR__ . '/../' . $path)) {
+                    return $path;
+                }
             }
         }
 


### PR DESCRIPTION
## Summary
- allow `Product::getImagePath()` to check multiple extensions when choosing local product images

## Testing
- `php -l classes/Product.php`
- `find . -name '*.php' | xargs -I{} php -l {}`
- `php test_system.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_b_68770a77480c83268fd367fd06284940