### PR TITLE
Improve database config handling

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -1,10 +1,18 @@
 <?php
 class Database {
-    private $host = 'localhost';
-    private $dbname = 'alquimia_technologic';
-    private $username = 'root';
-    private $password = '';
+    private $host;
+    private $dbname;
+    private $username;
+    private $password;
     private $pdo;
+
+    public function __construct() {
+        // Utiliza las constantes definidas en config.php para evitar valores duplicados
+        $this->host = defined('DB_HOST') ? DB_HOST : 'localhost';
+        $this->dbname = defined('DB_NAME') ? DB_NAME : '';
+        $this->username = defined('DB_USER') ? DB_USER : 'root';
+        $this->password = defined('DB_PASS') ? DB_PASS : '';
+    }
     
     public function connect() {
         try {


### PR DESCRIPTION
## Summary
- use constants from `config.php` in `Database` class

## Testing
- `php test_system.php` *(fails: SQLSTATE[HY000] [2002] No such file or directory)*
- `find . -name '*.php' | xargs -I{} php -l {}`

------
https://chatgpt.com/codex/tasks/task_b_687713274ad483268925510156423ed9